### PR TITLE
3.0.1

### DIFF
--- a/src/merlin.app.src
+++ b/src/merlin.app.src
@@ -1,7 +1,7 @@
 {application, merlin, [
     {pkg_name, "kivra_merlin"},
     {description, "Parse transform library for Erlang"},
-    {vsn, "3.0.0"},
+    {vsn, "3.0.1"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
Prepare to release 3.0.1 into the wild.

If we use `{vsn, git}` or `{vsn, semver}` instead of a specific version, this step can be skipped, which makes for one less step to publish.